### PR TITLE
Ported iclass config card generation from nfc-iclass

### DIFF
--- a/armsrc/Standalone/hf_msdsal.c
+++ b/armsrc/Standalone/hf_msdsal.c
@@ -304,15 +304,15 @@ void RunMod(void) {
                     LED_C_OFF();
                     LED_B_ON();
 
-    // add loop visa
-    // for (int i = 0; i < ARRAYLEN(AIDlist); i ++) {
+                    // add loop visa
+                    // for (int i = 0; i < ARRAYLEN(AIDlist); i ++) {
 //    hexstr_to_byte_array("a0da02631a440a44000000a012ad10a00e800200048108", sam_apdu, &sam_len);
                     uint8_t apdulen = iso14_apdu(apdus[i], (uint16_t) apduslen[i], false, apdubuffer, NULL);
 
                     if (apdulen > 0) {
                         DbpString("[ " _YELLOW_("Proxmark command") " ]");
                         Dbhexdump(apduslen[i], apdus[i], false);
-                        DbpString("[ " _GREEN_( "Card answer") " ]");
+                        DbpString("[ " _GREEN_("Card answer") " ]");
                         Dbhexdump(apdulen - 2, apdubuffer, false);
                         DbpString("-------------------------------");
 
@@ -447,7 +447,7 @@ void RunMod(void) {
                     p_response = &responses[RESP_INDEX_RATS];
 
                 } else {
-                    if (g_dbglevel == DBG_DEBUG ) {
+                    if (g_dbglevel == DBG_DEBUG) {
                         DbpString("[ "_YELLOW_("Card reader command") " ]");
                         Dbhexdump(len, receivedCmd, false);
                     }
@@ -459,14 +459,14 @@ void RunMod(void) {
                         // depending on card reader commands, the Proxmark will answer to fool the reader
                         // respond with PPSE
                         if (receivedCmd[2] == 0xA4 && receivedCmd[6] == 0x32 && prevCmd == 0) {
-                            // need to adapt lengths.. 
+                            // need to adapt lengths..
                             uint8_t ppsea[39] = {
-                            //        0x23 = 35,  skip two first bytes then the message - SW 2 is 35 = 0x23
+                                //        0x23 = 35,  skip two first bytes then the message - SW 2 is 35 = 0x23
                                 0x6F, 0x23, 0x84, 0x0E, 0x32, 0x50, 0x41, 0x59,
                                 0x2E, 0x53, 0x59, 0x53, 0x2E, 0x44, 0x44, 0x46,
                                 0x30, 0x31, 0xA5, 0x11, 0xBF, 0x0C, 0x0E, 0x61,
-                                0x0C, 0x4F, 
-                            //  len   aid0  aid1  aid2...
+                                0x0C, 0x4F,
+                                //  len   aid0  aid1  aid2...
                                 0x07, 0xA0, 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
                                 0x87, 0x01, 0x01, 0x90, 0x00
                             };
@@ -477,13 +477,13 @@ void RunMod(void) {
                             // respond Visa AID
                         } else if (receivedCmd[2] == 0xA4 && receivedCmd[10] == 0x03 && receivedCmd[11] == 0x10 && prevCmd == 1) {
                             uint8_t visauid_long[34] = {
-                        //          0x1E = 30,  skip two first bytes then the message - SW 2 is 30 = 0x1E
-                                0x6F, 0x1E, 0x84, 
-                        //      len   aid0  aid1  aid2....
-                                0x07, 0xA0, 0x00, 0x00, 0x00, 0x03, 0x10, 0x10, 
-                                0xA5, 0x13, 0x50, 
-                        //      len      V     I     S     A           C     R    E      D     I     T
-                                0x0B, 0x56, 0x49, 0x53, 0x41, 0x20, 0x43, 0x52, 0x45, 0x44, 0x49, 0x54, 
+                                //          0x1E = 30,  skip two first bytes then the message - SW 2 is 30 = 0x1E
+                                0x6F, 0x1E, 0x84,
+                                //      len   aid0  aid1  aid2....
+                                0x07, 0xA0, 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+                                0xA5, 0x13, 0x50,
+                                //      len      V     I     S     A           C     R    E      D     I     T
+                                0x0B, 0x56, 0x49, 0x53, 0x41, 0x20, 0x43, 0x52, 0x45, 0x44, 0x49, 0x54,
                                 0x9F, 0x38, 0x03, 0x9F, 0x66, 0x02,
                                 0x90, 0x00
                             };
@@ -503,7 +503,7 @@ void RunMod(void) {
                             uint8_t card[25] = {
                                 0x70, 0x15, 0x57, 0x13, 0x00, 0x00, 0x00, 0x00,
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                 0x90, 0x00
                             };
                             // add token array == Track 2 found before

--- a/armsrc/Standalone/hf_reblay.c
+++ b/armsrc/Standalone/hf_reblay.c
@@ -73,29 +73,25 @@ void ModInfo(void) {
 
 void RunMod() {
     StandAloneMode();
-    Dbprintf(_YELLOW_(">>")  "Relaying ISO/14443A data over Bluetooth a.k.a. reblay Started<<");
+    DbpString("");    
+    Dbprintf(_YELLOW_(">>> ")  " Relaying ISO/14443A data over Bluetooth a.k.a. reblay Started " _YELLOW_("<<<"));
+    DbpString("");
     FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
 
-// Allocate 512 bytes for the dynamic modulation, created when the reader queries for it
-// Such a response is less time critical, so we can prepare them on the fly
-#define DYNAMIC_RESPONSE_BUFFER_SIZE 512
-#define DYNAMIC_MODULATION_BUFFER_SIZE 1024
 
-    uint8_t flags = FLAG_4B_UID_IN_DATA; //UID 4 bytes(could be 7 bytes if needed it)
-    uint8_t data[PM3_CMD_DATA_SIZE] = {0x00}; // in case there is a read command received we shouldn't break
 
-    uint8_t visauid[7] = {0x01, 0x02, 0x03, 0x04};
+    // UID 4 bytes(could be 7 bytes if needed it)
+    uint8_t flags = FLAG_4B_UID_IN_DATA;
+    // in case there is a read command received we shouldn't break
+    uint8_t data[PM3_CMD_DATA_SIZE] = {0x00};
+
+    uint8_t visauid[7] = {0xE9, 0x66, 0x5D, 0x20};
     memcpy(data, visauid, 4);
 
     // to initialize the emulation
-    uint8_t tagType = 4; // 4 = ISO/IEC 14443-4 - javacard (JCOP)
     tag_response_info_t *responses;
 
     uint32_t cuid = 0;
-    uint32_t counters[3] = { 0x00, 0x00, 0x00 };
-    uint8_t tearings[3] = { 0xbd, 0xbd, 0xbd };
-    uint8_t pages = 0;
-
 
     // For received Bluetooth package
     uint8_t rpacket[MAX_FRAME_SIZE] = { 0x00 };
@@ -126,6 +122,12 @@ void RunMod() {
     uint8_t receivedCmd[MAX_FRAME_SIZE] = { 0x00 };
     uint8_t receivedCmdPar[MAX_PARITY_SIZE] = { 0x00 };
 
+
+// Allocate 512 bytes for the dynamic modulation, created when the reader queries for it
+// Such a response is less time critical, so we can prepare them on the fly
+#define DYNAMIC_RESPONSE_BUFFER_SIZE 512
+#define DYNAMIC_MODULATION_BUFFER_SIZE 1024
+
     uint8_t dynamic_response_buffer[DYNAMIC_RESPONSE_BUFFER_SIZE] = {0};
     uint8_t dynamic_modulation_buffer[DYNAMIC_MODULATION_BUFFER_SIZE] = {0};
 
@@ -143,9 +145,9 @@ void RunMod() {
     uint8_t state = STATE_READ;
 
     if (state == STATE_READ) {
-        DbpString(_YELLOW_("[ ") "In reading mode" _YELLOW_(" ]"));
+        DbpString("Initialized [ " _YELLOW_("reading mode") " ]");
     } else {
-        DbpString(_YELLOW_("[ ") "In emulation mode" _YELLOW_(" ]"));
+        DbpString("Initialized [ " _BLUE_("emulation mode") " ]");
     }
 
     for (;;) {
@@ -162,10 +164,10 @@ void RunMod() {
         else if (button_pressed == BUTTON_SINGLE_CLICK) { // Pressing one time change between reading & emulation
             if (state == STATE_READ) {
                 state = STATE_EMU;
-                DbpString(_YELLOW_("[ ") "In emulation mode" _YELLOW_(" ]"));
+                DbpString("[ " _BLUE_("Emulation mode") " ]");
             } else {
                 state = STATE_READ;
-                DbpString(_YELLOW_("[ ") "In reading mode" _YELLOW_(" ]"));
+                DbpString("[ " _YELLOW_("Reading mode") " ]");
             }
         }
 
@@ -178,6 +180,7 @@ void RunMod() {
 
             iso14443a_setup(FPGA_HF_ISO14443A_READER_MOD);
             if (iso14443a_select_card(NULL, &card_a_info, NULL, true, 0, false)) {
+
                 LED_B_ON();
 
                 // Get data to send a ping with UID + ATQA + SAK
@@ -208,7 +211,9 @@ void RunMod() {
                 Dbhexdump(uidlen + 4, rdata, false);
 
                 DbpString(_YELLOW_("[ ") "Sending ping" _YELLOW_(" ]"));
+
                 if (usart_writebuffer_sync(rdata, uidlen + 4) == PM3_SUCCESS) {
+
                     DbpString(_YELLOW_("[ ") "Sent!" _YELLOW_(" ]"));
 
                     for (;;) {
@@ -261,26 +266,31 @@ void RunMod() {
             // free eventually allocated BigBuf memory but keep Emulator Memory
             BigBuf_free_keep_EM();
 
-            if (SimulateIso14443aInit(tagType, flags, data, &responses, &cuid, counters, tearings, &pages) == false) {
+            // 4 = ISO/IEC 14443-4 - javacard (JCOP)
+            if (SimulateIso14443aInit(4, flags, data, &responses, &cuid, NULL, NULL, NULL) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
-                DbpString(_YELLOW_("!!") "Error initializing the emulation process!");
+                DbpString(_RED_("Error initializing the emulation process!"));
                 SpinDelay(500);
                 state = STATE_READ;
-                DbpString(_YELLOW_("[ ") "Initialized reading mode" _YELLOW_(" ]"));
+                DbpString("Initialized [ "_YELLOW_("reading mode") " ]");
                 continue;
             }
 
             // We need to listen to the high-frequency, peak-detected path.
             iso14443a_setup(FPGA_HF_ISO14443A_TAGSIM_LISTEN);
 
-            int len = 0; // Command length
-            int retval = PM3_SUCCESS; // Check emulation status
+            // Command length
+            int len = 0;
+            // Check emulation status
+            int retval = PM3_SUCCESS;
 
-            uint8_t resp = 0; // Bluetooth response
+            // Bluetooth response
+            uint8_t resp = 0; 
             lenpacket = 0;
 
-            uint8_t prevcmd = 0x00; // Keep track of last terminal type command
+            // Keep track of last terminal type command
+            uint8_t prevcmd = 0x00;
 
             clear_trace();
             set_tracing(true);
@@ -288,11 +298,12 @@ void RunMod() {
             for (;;) {
                 LED_B_OFF();
                 // Clean receive command buffer
-                if (!GetIso14443aCommandFromReader(receivedCmd, receivedCmdPar, &len)) {
-                    DbpString(_YELLOW_("!!") "Emulator stopped");
+                if (GetIso14443aCommandFromReader(receivedCmd, receivedCmdPar, &len) == false) {
+                    DbpString("Emulator stopped");
                     retval = PM3_EOPABORTED;
                     break;
                 }
+
                 tag_response_info_t *p_response = NULL;
                 LED_B_ON();
 
@@ -314,46 +325,42 @@ void RunMod() {
                     }
                 }
                 if (receivedCmd[0] == ISO14443A_CMD_REQA && len == 1) {  // Received a REQUEST
-//                    DbpString(_YELLOW_("+") "REQUEST Received");
                     p_response = &responses[RESP_INDEX_ATQA];
                 } else if (receivedCmd[0] == ISO14443A_CMD_HALT && len == 4) {  // Received a HALT
-//                    DbpString(_YELLOW_("+") "Received a HALT");
                     p_response = NULL;
                     resp = 0;
                 } else if (receivedCmd[0] == ISO14443A_CMD_WUPA && len == 1) {  // Received a WAKEUP
-//                    DbpString(_YELLOW_("+") "WAKEUP Received");
                     p_response = &responses[RESP_INDEX_ATQA];
                     resp = 0;
                 } else if (receivedCmd[1] == 0x20 && receivedCmd[0] == ISO14443A_CMD_ANTICOLL_OR_SELECT && len == 2) {  // Received request for UID (cascade 1)
-//                    DbpString(_YELLOW_("+") "Request for UID C1");
                     p_response = &responses[RESP_INDEX_UIDC1];
                 } else if (receivedCmd[1] == 0x70 && receivedCmd[0] == ISO14443A_CMD_ANTICOLL_OR_SELECT && len == 9) {  // Received a SELECT (cascade 1)
-//                    DbpString(_YELLOW_("+") "Request for SELECT S1");
                     p_response = &responses[RESP_INDEX_SAKC1];
                 } else if (receivedCmd[0] == ISO14443A_CMD_RATS && len == 4) {  // Received a RATS request
-//                    DbpString(_YELLOW_("+") "Request for RATS");
                     p_response = &responses[RESP_INDEX_RATS];
                     resp = 1;
                 } else if (receivedCmd[0] == 0xf2 && len == 4) {  // ACKed - Time extension
-                    DbpString(_YELLOW_("!!") "Reader accepted time extension!");
+                    DbpString(_YELLOW_("!!") " Reader accepted time extension!");
                     p_response = NULL;
                 } else if ((receivedCmd[0] == 0xb2 || receivedCmd[0] == 0xb3) && len == 3) { //NACK - Request more time WTX
-                    DbpString(_YELLOW_("!!") "NACK - time extension request?");
+                    DbpString(_YELLOW_("!!") " NACK - time extension request?");
                     if (resp == 2 && lenpacket == 0) {
-                        DbpString(_YELLOW_("!!") "Requesting more time - WTX");
+                        DbpString(_YELLOW_("!!") " Requesting more time - WTX");
                         dynamic_response_info.response_n = 2;
                         dynamic_response_info.response[0] = 0xf2;
                         dynamic_response_info.response[1] = 0x0b;  // Requesting the maximum amount of time
                     } else if (lenpacket == 0) {
-                        DbpString(_YELLOW_("!!") "NACK - ACK - Resend last command!"); // To burn some time as well
+                        DbpString(_YELLOW_("!!") " NACK - ACK - Resend last command!"); // To burn some time as well
                         dynamic_response_info.response[0] = 0xa3;
                         dynamic_response_info.response_n = 1;
                     } else {
-                        DbpString(_YELLOW_("!!") "Avoiding request - Bluetooth data already in memory!!");
+                        DbpString(_YELLOW_("!!") " Avoiding request - Bluetooth data already in memory!!");
                     }
                 } else {
-                    DbpString(_GREEN_("[ ") "Card reader command" _GREEN_(" ]"));
-                    Dbhexdump(len - 2, &receivedCmd[1], false);
+                    if (g_dbglevel == DBG_DEBUG ) {
+                        DbpString("[ "_YELLOW_("Card reader command") " ]");
+                        Dbhexdump(len - 2, &receivedCmd[1], false);
+                    }
 
                     if ((receivedCmd[0] == 0x02 || receivedCmd[0] == 0x03) && len > 3) { // Process reader commands
 
@@ -379,16 +386,17 @@ void RunMod() {
 
                     } else {
                         if (lenpacket == 0) {
-                            DbpString(_YELLOW_("!!") "Received unknown command!");
+                            DbpString(_RED_("Received unknown command!"));
                             memcpy(dynamic_response_info.response, receivedCmd, len);
                             dynamic_response_info.response_n = len;
                         } else {
-                            DbpString(_YELLOW_("!!") "Avoiding unknown command - Bluetooth data already in memory!!");
+                            DbpString(_YELLOW_("!!") " Avoiding unknown command - Bluetooth data already in memory !!");
                         }
                     }
                 }
+
                 if (dynamic_response_info.response_n > 0) {
-                    DbpString(_GREEN_("[ ") "Proxmark3 answer" _GREEN_(" ]"));
+                    DbpString("[ " _GREEN_("Proxmark3 answer") " ]");
                     Dbhexdump(dynamic_response_info.response_n, dynamic_response_info.response, false);
                     DbpString("----");
                     if (lenpacket > 0) {
@@ -402,7 +410,7 @@ void RunMod() {
                     if (prepare_tag_modulation(&dynamic_response_info, DYNAMIC_MODULATION_BUFFER_SIZE) == false) {
                         Dbprintf(_YELLOW_("[ ") "Buffer size: %d "_YELLOW_(" ]"), dynamic_response_info.response_n);
                         SpinDelay(500);
-                        DbpString(_YELLOW_("!!") "Error preparing Proxmark to answer!");
+                        DbpString(_RED_("Error preparing Proxmark to answer!"));
                         continue;
                     }
                     p_response = &dynamic_response_info;
@@ -412,13 +420,15 @@ void RunMod() {
                     EmSendPrecompiledCmd(p_response);
                 }
             }
-            switch_off();
 
+            switch_off();
             set_tracing(false);
             BigBuf_free_keep_EM();
             reply_ng(CMD_HF_MIFARE_SIMULATE, retval, NULL, 0);
         }
     }
-    DbpString(_YELLOW_("[=]") "exiting");
+    DbpString("Exit standalone mode!");
+    DbpString("");
+    SpinErr(15, 200, 3);
     LEDsoff();
 }

--- a/armsrc/Standalone/hf_reblay.c
+++ b/armsrc/Standalone/hf_reblay.c
@@ -73,7 +73,7 @@ void ModInfo(void) {
 
 void RunMod() {
     StandAloneMode();
-    DbpString("");    
+    DbpString("");
     Dbprintf(_YELLOW_(">>> ")  " Relaying ISO/14443A data over Bluetooth a.k.a. reblay Started " _YELLOW_("<<<"));
     DbpString("");
     FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
@@ -286,7 +286,7 @@ void RunMod() {
             int retval = PM3_SUCCESS;
 
             // Bluetooth response
-            uint8_t resp = 0; 
+            uint8_t resp = 0;
             lenpacket = 0;
 
             // Keep track of last terminal type command
@@ -357,7 +357,7 @@ void RunMod() {
                         DbpString(_YELLOW_("!!") " Avoiding request - Bluetooth data already in memory!!");
                     }
                 } else {
-                    if (g_dbglevel == DBG_DEBUG ) {
+                    if (g_dbglevel == DBG_DEBUG) {
                         DbpString("[ "_YELLOW_("Card reader command") " ]");
                         Dbhexdump(len - 2, &receivedCmd[1], false);
                     }

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -1021,7 +1021,7 @@ bool prepare_allocated_tag_modulation(tag_response_info_t *response_info, uint8_
     }
 }
 
-bool SimulateIso14443aInit(uint8_t tagType, uint16_t flags, uint8_t *data, tag_response_info_t **responses, 
+bool SimulateIso14443aInit(uint8_t tagType, uint16_t flags, uint8_t *data, tag_response_info_t **responses,
                            uint32_t *cuid, uint32_t counters[3], uint8_t tearings[3], uint8_t *pages) {
     uint8_t sak = 0;
     // The first response contains the ATQA (note: bytes are transmitted in reverse order).
@@ -1042,7 +1042,7 @@ bool SimulateIso14443aInit(uint8_t tagType, uint16_t flags, uint8_t *data, tag_r
     // Format byte = 0x58: FSCI=0x08 (FSC=256), TA(1) and TC(1) present,
     // TA(1) = 0x80: different divisors not supported, DR = 1, DS = 1
     // TB(1) = not present. Defaults: FWI = 4 (FWT = 256 * 16 * 2^4 * 1/fc = 4833us), SFGI = 0 (SFG = 256 * 16 * 2^0 * 1/fc = 302us)
-    // TC(1) = 0x02: CID supported, NAD not supported    
+    // TC(1) = 0x02: CID supported, NAD not supported
 //    static uint8_t rRATS[] = { 0x04, 0x58, 0x80, 0x02, 0x00, 0x00 };
     static uint8_t rRATS[40] = { 0x05, 0x75, 0x80, 0x60, 0x02, 0x00, 0x00, 0x00 };
     uint8_t rRATS_len = 8;
@@ -1314,10 +1314,10 @@ bool SimulateIso14443aInit(uint8_t tagType, uint16_t flags, uint8_t *data, tag_r
     // since rats len is variable now.
     responses_init[RESP_INDEX_RATS].response_n = rRATS_len;
 
-    // "precompiled" responses. 
+    // "precompiled" responses.
     // These exist for speed reasons.  There are no time in the anti collision phase to calculate responses.
     // There are 12 predefined responses with a total of 84 bytes data to transmit.
-    // 
+    //
     // Coded responses need one byte per bit to transfer (data, parity, start, stop, correction)
     // 85 * 8 data bits, 85 * 1 parity bits, 12 start bits, 12 stop bits, 12 correction bits
     // 85 * 8 + 85 + 12 + 12 + 12 == 801

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -2772,7 +2772,7 @@ static void detect_credential(uint8_t *iclass_dump, size_t dump_len, bool *is_le
     picopass_hdr_t *hdr = (picopass_hdr_t *)iclass_dump;
 
     if (!memcmp(hdr->app_issuer_area, "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", PICOPASS_BLOCK_SIZE)) {
-    // Legacy AIA
+        // Legacy AIA
         *is_legacy = true;
 
         if (dump_len < 11 * PICOPASS_BLOCK_SIZE) {

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4450,7 +4450,7 @@ static command_t CommandTable[] = {
     {"esetblk",     CmdHFiClassESetBlk,         IfPm3Iclass,     "Set emulator memory block data"},
     {"eview",       CmdHFiClassEView,           IfPm3Iclass,     "View emulator memory"},
     {"-----------", CmdHelp,                    AlwaysAvailable, "---------------------- " _CYAN_("utils") " ----------------------"},
-    {"configcard",  CmdHFiClassConfigCard,      AlwaysAvailable, "Reader configuration card"},
+    {"configcard",  CmdHFiClassConfigCard,      IfPm3Smartcard,  "Reader configuration card"},
     {"calcnewkey",  CmdHFiClassCalcNewKey,      AlwaysAvailable, "Calc diversified keys (blocks 3 & 4) to write new keys"},
     {"encode",      CmdHFiClassEncode,          AlwaysAvailable, "Encode binary wiegand to block 7"},
     {"encrypt",     CmdHFiClassEncryptBlk,      AlwaysAvailable, "Encrypt given block data"},

--- a/client/src/emv/cmdemv.c
+++ b/client/src/emv/cmdemv.c
@@ -53,7 +53,7 @@ static void ParamLoadDefaults(struct tlvdb *tlvRoot) {
     TLV_ADD(0x5F2A, "\x090\x78");
     // 9A:(Transaction Date) len:3
     TLV_ADD(0x9A,   "\x00\x00\x00");
-    // 9C:(Transaction Type) len:1 
+    // 9C:(Transaction Type) len:1
     //     | 00 => Goods and Service
     //     | 01 => Cash
     TLV_ADD(0x9C,   "\x00");
@@ -544,7 +544,7 @@ static int emv_parse_card_details(uint8_t *response, size_t reslen, bool verbose
 
     // Track 3 Data
     // to be impl.
-   
+
     // Unpredicable Number (UN)
     struct tlvdb *un1_full = tlvdb_find_full(root, 0x9f37);
     if (un1_full != NULL) {
@@ -2018,7 +2018,7 @@ static int CmdEMVScan(const char *Cmd) {
     bool paramLoadJSON = arg_get_lit(ctx, 4);
 
     enum TransactionType TrType = TT_MSD;
-    if (arg_get_lit(ctx, 6)){
+    if (arg_get_lit(ctx, 6)) {
         TrType = TT_QVSDCMCHIP;
     }
     if (arg_get_lit(ctx, 7)) {

--- a/client/src/iso7816/iso7816core.c
+++ b/client/src/iso7816/iso7816core.c
@@ -205,14 +205,14 @@ int Iso7816Select(Iso7816CommandChannel channel, bool activate_field, bool leave
                   uint8_t *result, size_t max_result_len, size_t *result_len, uint16_t *sw) {
 
     return Iso7816ExchangeEx(channel
-                , activate_field
-                , leave_field_on
-                , (sAPDU_t) {0x00, 0xa4, 0x04, 0x00, aid_len, aid}
-                , (channel == CC_CONTACTLESS)
-                , 0
-                , result
-                , max_result_len
-                , result_len
-                , sw
-            );
+                             , activate_field
+                             , leave_field_on
+    , (sAPDU_t) {0x00, 0xa4, 0x04, 0x00, aid_len, aid}
+    , (channel == CC_CONTACTLESS)
+    , 0
+    , result
+    , max_result_len
+    , result_len
+    , sw
+                            );
 }

--- a/client/src/pm3line_vocabulary.h
+++ b/client/src/pm3line_vocabulary.h
@@ -285,7 +285,7 @@ const static vocabulary_t vocabulary[] = {
     { 0, "hf iclass esave" },
     { 0, "hf iclass esetblk" },
     { 0, "hf iclass eview" },
-    { 1, "hf iclass configcard" },
+    { 0, "hf iclass configcard" },
     { 1, "hf iclass calcnewkey" },
     { 1, "hf iclass encode" },
     { 1, "hf iclass encrypt" },

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -11857,6 +11857,6 @@
     "metadata": {
         "commands_extracted": 687,
         "extracted_by": "PM3Help2JSON v1.00",
-        "extracted_on": "2023-10-03T15:10:12"
+        "extracted_on": "2023-10-12T12:53:10"
     }
 }

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -424,7 +424,7 @@ Check column "offline" for their availability.
 |`hf iclass esave        `|N       |`Save emulator memory to file`
 |`hf iclass esetblk      `|N       |`Set emulator memory block data`
 |`hf iclass eview        `|N       |`View emulator memory`
-|`hf iclass configcard   `|Y       |`Reader configuration card`
+|`hf iclass configcard   `|N       |`Reader configuration card`
 |`hf iclass calcnewkey   `|Y       |`Calc diversified keys (blocks 3 & 4) to write new keys`
 |`hf iclass encode       `|Y       |`Encode binary wiegand to block 7`
 |`hf iclass encrypt      `|Y       |`Encrypt given block data`

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -444,7 +444,7 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 // Picopass Pagemode fuses
 #define PICOPASS_SECURE_PAGEMODE_AUTH_DISABLED      0x00
 #define PICOPASS_NON_SECURE_PAGEMODE                0x01
-#define PICOPASS_SECURE_PAGEMODE_KEYS_LOCKED        0x02 
+#define PICOPASS_SECURE_PAGEMODE_KEYS_LOCKED        0x02
 #define PICOPASS_SECURE_PAGEMODE_KEYS_MODIFIABLE    0x03
 
 // ISO 7816-4 Basic interindustry commands. For command APDU's.


### PR DESCRIPTION
Changes:

1- Ported iclass configcard generation data from nfc-iclass
2- Should still support pulling data from cardhelper, but now works also without cardhelper installed
3- Fixed configcard to only be available in online mode (missed one spot in my previous commit)